### PR TITLE
remove unnecessary perl modules from Exodus tests

### DIFF
--- a/tools/test_modules/m28200.pm
+++ b/tools/test_modules/m28200.pm
@@ -8,11 +8,9 @@
 use strict;
 use warnings;
 
-use Crypt::ScryptKDF qw (scrypt_hash scrypt_raw);
-use Crypt::CBC;
-use MIME::Base64 qw (decode_base64 encode_base64);
-use Digest::SHA qw (sha512);
 use Crypt::AuthEnc::GCM;
+use Crypt::ScryptKDF qw (scrypt_raw);
+use MIME::Base64     qw (decode_base64 encode_base64);
 
 sub module_constraints { [[0, 256], [64, 64], [-1, -1], [-1, -1], [-1, -1]] }
 


### PR DESCRIPTION
For the test unit file `tools/test_modules/m28200.pm` the perl modules `Crypt::CBC` and `Digest::SHA` are not needed and were not used at all. Furthermore, the function `scrypt_hash ()` was never called.

I've cleaned this test code up a little bit.

Thanks